### PR TITLE
Add links to slides and video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # nyhackr_talk
+
+[View slides](https://raw.githack.com/ljanda/nyhackr_talk_2019_09_19/master/ny_hackr_talk_2019_09_19.html)
+
+[View video](https://www.youtube.com/watch?v=yrZS8mGL-2E)


### PR DESCRIPTION
Nice slides!

I find it useful to have direct links to the slides in your readme, so people can easily view them from the GitHub page. You can do it generally by pasting the raw link for the HTML slides into https://raw.githack.com/.

Since you had the video recording I also put that in the readme, cause why not!